### PR TITLE
[Chore] /issue 커맨드 추가 및 /pr 커맨드 템플릿 직접 참조 개선

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,59 @@
+---
+name: issue
+description: Creates a GitHub issue using the project's ISSUE_TEMPLATE for the given type. Reads the matching template and fills it in. Usage: /issue <type> <title> (type: feature | bug | refactor | chore | design)
+---
+
+You will create a GitHub issue using the project's issue templates.
+
+## Step 1 — Parse Arguments
+
+The user's input after `/issue` follows this format:
+```
+/issue <type> <title>
+```
+
+- `<type>`: one of `feature`, `bug`, `refactor`, `chore`, `design`
+- `<title>`: brief description of the issue (everything after the type)
+
+If no type is given, ask the user: "어떤 타입의 이슈인가요? (feature / bug / refactor / chore / design)"
+If no title is given, ask the user: "이슈 제목을 입력해주세요."
+
+## Step 2 — Read the Template
+
+Based on `<type>`, read the corresponding template file:
+
+| type     | file                                      |
+|----------|-------------------------------------------|
+| feature  | `.github/ISSUE_TEMPLATE/feature.md`       |
+| bug      | `.github/ISSUE_TEMPLATE/bug.md`           |
+| refactor | `.github/ISSUE_TEMPLATE/refactor.md`      |
+| chore    | `.github/ISSUE_TEMPLATE/chore.md`         |
+| design   | `.github/ISSUE_TEMPLATE/design.md`        |
+
+Strip the YAML frontmatter (everything between the first `---` and the second `---`) from the template body before using it.
+
+## Step 3 — Fill the Template
+
+Use the template body as the issue body structure. Fill in what you can from the title and context. Leave placeholder lines (e.g., `>`, empty checkboxes) as-is for the user to complete later.
+
+- For `feature`: fill the 개요 section from the title; leave Tasks and DoD as empty checkboxes
+- For `bug`: fill the 문제 상황 section from the title; leave 재현 방법, 환경 as placeholders
+- For `refactor`: fill 개선 내용 from the title; leave 영향 범위 as placeholders
+- For `chore`: fill 작업 내용 from the title; leave 작업 리스트 as empty checkboxes
+- For `design`: fill 주제 from the title; leave 고려 사항 and 결론 as placeholders
+
+## Step 4 — Determine Label and Title Format
+
+From the template frontmatter, extract the `labels` field to use as the issue label.
+Title format: `[Type] <title>` — capitalize the type (e.g., `[Feature]`, `[Bug]`).
+
+## Step 5 — Create the Issue
+
+Use `gh issue create` with:
+- `--title "[Type] <title>"`
+- `--label "<label from template>"`
+- `--body` containing the filled template body (use HEREDOC to preserve formatting)
+
+## Final Output
+
+Print the issue URL after creation.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -7,12 +7,12 @@ You will create a GitHub Pull Request for the current branch following the proje
 
 ## Step 1 — Gather Information
 
-Run these commands to understand what changed:
+Run these commands in parallel to understand what changed:
 - `git log develop..HEAD --oneline` — commit list
 - `git diff develop...HEAD --stat` — changed files summary
 - `git diff develop...HEAD` — full diff (for understanding changes)
 
-Also read `.github/pull-request-template.md` to know the required format.
+Then read `.github/pull-request-template.md` to get the exact template format. Use the template as-is — do not invent or skip any section.
 
 ## Step 2 — Determine PR Type
 
@@ -25,48 +25,27 @@ Based on the changes, determine the type label:
 
 ## Step 3 — Check Line Count
 
-Run `git diff develop...HEAD --stat` and count total lines changed.
-- If over 200 lines: warn the user and suggest splitting (project rule: PR must be ≤ 200 lines)
-- If using `stacked-pr` label: the 200-line limit is skipped
+Parse the `--stat` output and sum the insertions + deletions.
+- If over 200 lines: warn the user and ask for confirmation before proceeding (project rule: PR must be ≤ 200 lines)
+- Exception: if the branch contains a `stacked-pr` label or the user confirms, proceed anyway
 
-## Step 4 — Create the PR
+## Step 4 — Fill the Template
 
-Use `gh pr create` with the following body structure (fill in from the diff):
+Read `.github/pull-request-template.md` and fill in each section from the diff and commit history:
+- **PR title**: `[Type] 한 줄 요약` (match the title format shown at the top of the template)
+- **PR 개요**: one-line summary of what this PR does
+- **작업 내용**: checkbox list derived from actual changes
+- **관련 이슈**: use `Closes #N` if an issue number was passed as argument (e.g. `/pr 42` → `Closes #42`); omit if none
+- **화면 캡처**: leave placeholder text as-is (user fills this manually)
+- **체크 사항**: keep all checkboxes unchecked — do not pre-check any
+- **기타 참고 사항**: brief note for reviewers about non-obvious decisions or tradeoffs, if any
 
-```
-제목 형식: [Type] 작업 내용 한 줄 요약
+## Step 5 — Create the PR
 
-## 📌 PR 개요
-- [한 줄 요약]
-
----
-
-## ✨ 작업 내용
-- [ ] [변경 사항 1]
-- [ ] [변경 사항 2]
-
----
-
-## 🧩 관련 이슈
-- Closes #[이슈 번호] (사용자가 제공한 경우)
-
----
-
-## ⚠️ 체크 사항
-- [ ] 빌드 및 실행 정상 동작 확인
-- [ ] 기존 기능에 영향 없음
-- [ ] 변경 사항에 대한 테스트 작성 또는 기존 테스트 통과 확인
-- [ ] PR 변경 줄 수 200줄 이하 확인
-- [ ] 불필요한 로그 제거
-- [ ] 코드 컨벤션 준수
-
----
-
-## 💬 기타 참고 사항
-- [리뷰어가 알아야 할 사항]
-```
-
-Target branch: `develop`
+Use `gh pr create` with:
+- `--base develop`
+- `--title "[Type] 한 줄 요약"`
+- `--body` containing the filled template (use HEREDOC to preserve formatting)
 
 ## Final Output
 


### PR DESCRIPTION
> **제목 형식**: `[Chore] /issue 커맨드 추가 및 /pr 커맨드 템플릿 직접 참조 개선`

## 📌 PR 개요
- Claude Code `/issue`, `/pr` 슬래시 커맨드가 `.github` 템플릿 파일을 런타임에 직접 읽도록 개선

---

## ✨ 작업 내용
- [x] `.claude/commands/issue.md` 신규 추가 — `/issue <type> <title>` 형식으로 타입별 ISSUE_TEMPLATE을 읽어 `gh issue create` 자동 호출 (feature / bug / refactor / chore / design)
- [x] `.claude/commands/pr.md` 개선 — 하드코딩된 템플릿 제거, `pull-request-template.md` 런타임 직접 읽기 명시 및 섹션별 채우기 방식 명확화

---

## 🧩 관련 이슈
- Closes #41

---

## 📱 화면 캡처 (선택)
- 해당 없음 (코드 변경 없음)

---

## ⚠️ 체크 사항
- [x] 빌드 및 실행 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 변경 사항에 대한 테스트 작성 또는 기존 테스트 통과 확인
- [x] PR 변경 줄 수 200줄 이하 확인
- [x] 불필요한 로그 제거
- [x] 코드 컨벤션 준수

---

## 💬 기타 참고 사항
- Claude Code 커맨드 파일만 변경되어 앱 빌드/런타임에 영향 없음
- 템플릿 파일(`.github/`)이 변경되어도 커맨드 수정 없이 자동 반영됨