### PR TITLE
[Chore] GitHub 관리 커맨드 & 에이전트 추가·개선

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -16,12 +16,14 @@
 | `feature-refactorer.md` | `feature-refactorer` | 코드 품질 개선 (중복 제거, Kotlin 관용구) | Read, Glob, Grep, Edit |
 | `feature-reviewer.md` | `feature-reviewer` | 버그·보안·아키텍처 최종 리뷰 | Read, Glob, Grep |
 | `bug-analyzer.md` | `bug-analyzer` | 버그 원인 분석 → 수정 계획 수립 | Read, Glob, Grep |
+| `github-issue-helper.md` | `github-issue-helper` | 이슈 템플릿 본문 자동 작성 | Read, Glob, Grep |
 
 ## 에이전트 체인 구조
 
 ```
 /feature  →  feature-planner → feature-coder → feature-refactorer → feature-reviewer
 /bug      →  bug-analyzer    → feature-coder → feature-reviewer
+/issue    →  github-issue-helper
 ```
 
 ## 에이전트 추가 방법

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -16,7 +16,7 @@
 | `feature-refactorer.md` | `feature-refactorer` | 코드 품질 개선 (중복 제거, Kotlin 관용구) | Read, Glob, Grep, Edit |
 | `feature-reviewer.md` | `feature-reviewer` | 버그·보안·아키텍처 최종 리뷰 | Read, Glob, Grep |
 | `bug-analyzer.md` | `bug-analyzer` | 버그 원인 분석 → 수정 계획 수립 | Read, Glob, Grep |
-| `github-issue-helper.md` | `github-issue-helper` | 이슈 템플릿 본문 자동 작성 | Read, Glob, Grep |
+| `github-issue-helper.md` | `github-issue-helper` | 이슈 템플릿 타이틀·본문 자동 작성 (`SUMMARY:` + body 구조 출력) | Read, Glob, Grep |
 
 ## 에이전트 체인 구조
 

--- a/.claude/agents/github-issue-helper.md
+++ b/.claude/agents/github-issue-helper.md
@@ -40,7 +40,12 @@ grep -r "class DrugViewModel" --include="*.kt"
 grep -r "class UserRepository" --include="*.kt"
 ```
 
-Include the path in the filled template (e.g., "Related file: `app/feature/drug/presentation/DrugViewModel.kt`").
+**When multiple matches exist:**
+- If 2+ results found, prioritize based on user-provided context (screen name, feature module)
+- If still ambiguous, list all matching paths with a note: "(여러 파일에서 발견됨)"
+- If no matches, note as: "(파일을 찾을 수 없음)"
+
+Include the path(s) in the filled template (e.g., "Related file: `app/feature/drug/presentation/DrugViewModel.kt`").
 
 ## Step 3 — Fill Template Sections
 
@@ -61,13 +66,19 @@ For each section in the template (e.g., `## 🧩 개요`, `## 🎯 목표`):
 | 🧩 개요 (feature) | One-line summary of the feature |
 | 🎯 목표 (feature) | Extract user value + problem solved |
 | 🏗 설계 요약 (feature, optional) | If mentioned, extract UI/Domain/Data changes |
-| 🛠 작업 내용 | Identify which sections are relevant based on type |
+| 🛠 작업 내용 (chore) | Extract scope of work (new file/code generation), mark affected areas |
+| 🔧 개선 방안 (refactor) | Extract target state and why (performance, readability, maintainability) |
+| 📌 고려 사항 (design) | Extract design alternatives or constraints from description |
 
 ## Step 4 — Output Format
 
-Print the completed issue body exactly as it should appear in `gh issue create --body`:
+Print the completed issue in two-part format:
 
-```markdown
+```
+SUMMARY: 앱을 열고 약국 목록에서 스크롤 시 NPE 발생
+
+---
+
 ## 🐞 문제 상황
 앱을 열고 약국 목록 화면에서 스크롤을 내리면 NPE가 발생하며 앱이 크래시합니다.
 
@@ -84,10 +95,31 @@ Print the completed issue body exactly as it should appear in `gh issue create -
 ...
 ```
 
-**IMPORTANT**: Output ONLY the completed body markdown, nothing else. No explanations, no metadata, no "## Issue Body" header. The command will pipe this directly to `gh issue create --body`.
+**Output Structure:**
+1. **First line**: `SUMMARY: <한 줄 요약>` (max 70 characters for GitHub title)
+2. **Separator**: `---` (blank line before and after)
+3. **Body**: Complete markdown template sections
+
+**IMPORTANT**:
+- The `SUMMARY:` line will be extracted by orchestrator (issue.md) as the issue title
+- Everything after `---` becomes the issue body
+- Output ONLY the completed structure, nothing else. No explanations, no metadata
 
 ## Error Handling
 
-- If description is too vague (e.g., "it doesn't work"), ask for clarification by including a "❓ 추가 정보 필요" section
-- If a file/class is mentioned but not found, note it as "(파일을 찾을 수 없음)"
-- Do NOT fail the agent — always return a partially filled template
+**Vague Description Detection:**
+- Mark as vague if: description is <10 tokens (words) OR lacks type-critical info:
+  - **bug**: no error message, crash log, or reproduction steps
+  - **feature**: no user value or problem statement
+  - **chore**: no scope or affected files
+  - **refactor**: no target state or motivation
+  - **design**: no alternatives or constraints
+- When detected: include `❓ 추가 정보 필요` section at top with sample questions
+
+**File/Class Search:**
+- If mentioned but not found: note as "(파일을 찾을 수 없음)"
+- If multiple matches: list all with note "(여러 파일에서 발견됨)" and prioritize by context
+
+**General:**
+- Do NOT fail the agent — always return a partially filled template with `❓` markers for missing sections
+- Output SUMMARY and body structure even if incomplete

--- a/.claude/agents/github-issue-helper.md
+++ b/.claude/agents/github-issue-helper.md
@@ -1,0 +1,93 @@
+---
+name: github-issue-helper
+description: Auto-fills issue template sections by parsing user description and identifying file/class references. Called by /issue command.
+tools: Read, Glob, Grep
+---
+
+You are a GitHub issue template auto-fill agent for HelloDoctor-android.
+
+## Task
+
+Given:
+1. **Issue type** (bug, feature, chore, refactor, design)
+2. **User description** (natural language explaining the issue/feature)
+3. **Template body** (raw markdown from .github/ISSUE_TEMPLATE/{type}.md, YAML frontmatter already removed)
+
+Fill in the template sections intelligently:
+- Extract key information from the user description
+- If the description mentions a file, class, or component name, use Grep to find its actual path
+- Preserve section headers and checklist structure
+- Do NOT add sections that aren't in the original template
+
+## Step 1 — Parse User Description
+
+Extract:
+- **Main summary** (first 1-2 sentences)
+- **Context** (why this is needed)
+- **Details** (specific files, classes, error messages, reproduction steps)
+- **Scope** (what affects this)
+
+## Step 2 — Search for File/Class References (if mentioned)
+
+If the description mentions:
+- A file name (e.g., "DrugViewModel.kt")
+- A class name (e.g., "UserRepository")
+- A feature name (e.g., "약국 목록 화면")
+
+Use `Grep` to find the actual file path:
+```bash
+grep -r "class DrugViewModel" --include="*.kt"
+grep -r "class UserRepository" --include="*.kt"
+```
+
+Include the path in the filled template (e.g., "Related file: `app/feature/drug/presentation/DrugViewModel.kt`").
+
+## Step 3 — Fill Template Sections
+
+For each section in the template (e.g., `## 🧩 개요`, `## 🎯 목표`):
+
+1. **Existing headers**: Keep them as-is
+2. **Placeholder text** (starting with `>`): Replace with content extracted from user description
+3. **Checkboxes** (- [ ]): Keep structure, use checkboxes as-is
+4. **Code blocks or bullet points**: Preserve format, fill in with relevant details
+
+**Section-specific logic:**
+
+| Section | Logic |
+|---------|-------|
+| 🐞 문제 상황 (bug) | Extract error message, crash log, or unexpected behavior |
+| 🧪 재현 방법 (bug) | Parse user description for steps; if missing, ask typical questions |
+| 🤔 예상 동작 (bug) | Expected vs. actual behavior from description |
+| 🧩 개요 (feature) | One-line summary of the feature |
+| 🎯 목표 (feature) | Extract user value + problem solved |
+| 🏗 설계 요약 (feature, optional) | If mentioned, extract UI/Domain/Data changes |
+| 🛠 작업 내용 | Identify which sections are relevant based on type |
+
+## Step 4 — Output Format
+
+Print the completed issue body exactly as it should appear in `gh issue create --body`:
+
+```markdown
+## 🐞 문제 상황
+앱을 열고 약국 목록 화면에서 스크롤을 내리면 NPE가 발생하며 앱이 크래시합니다.
+
+## 🧪 재현 방법
+1. 앱 실행
+2. "약국" 탭 선택
+3. 목록을 아래로 스크롤
+4. 10개 이상 스크롤 시 크래시
+
+## 🤔 예상 동작
+목록이 부드럽게 스크롤되어야 합니다.
+
+## ❗ 실제 동작
+...
+```
+
+**IMPORTANT**: Output ONLY the completed body markdown, nothing else. No explanations, no metadata, no "## Issue Body" header. The command will pipe this directly to `gh issue create --body`.
+
+## Error Handling
+
+- If description is too vague (e.g., "it doesn't work"), ask for clarification by including a "❓ 추가 정보 필요" section
+- If a file/class is mentioned but not found, note it as "(파일을 찾을 수 없음)"
+- Do NOT fail the agent — always return a partially filled template

--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -20,6 +20,11 @@
 
 ---
 
+> **참고**: `/issue`·`/workflow`는 GitHub CLI(`gh`)가 설치·인증된 상태에서만 동작합니다.
+> 미설치 시: https://cli.github.com | 인증: `gh auth login`
+
+---
+
 ## 상세 설명
 
 ### `/feature` — 기능 구현 파이프라인
@@ -74,6 +79,42 @@ Happy path, Error path, Edge case를 모두 커버합니다.
 ```
 /test feature/drug/presentation/DrugViewModel.kt
 /test UserInfoRepositoryImpl
+```
+
+---
+
+### `/issue` — GitHub 이슈 생성
+
+이슈 타입과 설명을 받아 템플릿을 자동으로 채워 GitHub 이슈를 생성합니다.
+- 타입: `bug`/`버그`, `feature`/`기능`, `chore`/`보수`, `refactor`/`리팩`, `design`/`디자인`
+- 생성 전 타이틀·본문 미리보기 확인 단계 포함
+- label(`🐞 bug` 등), `📌 status: todo` 자동 적용
+
+```
+/issue bug 약국 목록 화면에서 스크롤 시 NPE 발생
+/issue feature 즐겨찾기 기능 추가
+/issue chore gradle 버전 업그레이드
+```
+
+---
+
+### `/workflow` — CI 워크플로우 관리
+
+GitHub Actions 워크플로우 상태 확인, 로그 조회, 실패 재실행을 수행합니다.
+
+| 서브커맨드 | 용도 |
+|-----------|------|
+| `status` (기본) | 현재 브랜치의 최근 10개 실행 결과 표시 |
+| `check` | HEAD 커밋의 모든 워크플로우 결과 집계 (실패 로그 포함) |
+| `rerun <id\|name>` | 실패한 단계만 재실행 + 완료까지 폴링 |
+| `list` | 저장소의 전체 워크플로우 목록 |
+
+```
+/workflow
+/workflow check
+/workflow rerun test-coverage
+/workflow rerun 12344
+/workflow list
 ```
 
 ---

--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -15,6 +15,8 @@
 | `/pr` | PR 자동 생성 | 단독 (git + gh 명령) |
 | `/api` | Retrofit 엔드포인트 스캐폴딩 | 단독 (coder 패턴 참조) |
 | `/test` | 유닛 테스트 자동 생성 | 단독 |
+| `/issue` | GitHub 이슈 생성 | github-issue-helper |
+| `/workflow` | CI 워크플로우 상태 확인·재실행 | 단독 (gh run 명령) |
 
 ---
 

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -24,7 +24,21 @@ Read the matching template from `.github/ISSUE_TEMPLATE/<type>.md`.
 - Extract the YAML frontmatter to get `labels` field (e.g., `labels: bug`)
 - Extract the body sections (everything after `---`)
 
-## Step 3 — Call github-issue-helper Agent
+## Step 3 — Validate GitHub CLI
+
+Check if GitHub CLI is installed and authenticated:
+
+```bash
+gh auth status
+```
+
+If failed:
+- Not installed: "❌ GitHub CLI가 설치되지 않았습니다. https://cli.github.com 에서 설치하세요."
+- Not authenticated: "❌ GitHub 인증이 필요합니다. `gh auth login`을 실행하세요."
+
+Proceed only if successful.
+
+## Step 4 — Call github-issue-helper Agent
 
 Pass the template content and user's description to the `github-issue-helper` agent:
 
@@ -37,17 +51,59 @@ Template body:
 """)
 ```
 
-The agent will auto-fill template sections and return a completed issue body.
+The agent will return a two-part output:
+- **SUMMARY: ...** (single line)
+- **---** (separator)
+- **Issue body** (markdown template)
 
-## Step 4 — Create the Issue
+## Step 5 — Parse Agent Output
+
+Extract from agent response:
+1. **First line** matching `SUMMARY: ...` → Extract text after `SUMMARY: ` as issue title
+2. **Content after `---` separator** → Complete markdown body
+
+Structure:
+```
+SUMMARY: 약국 목록 NPE 버그
+
+---
+
+## 🐞 문제 상황
+...
+```
+
+Parse to get:
+- Title: `약국 목록 NPE 버그`
+- Body: everything after `---`
+
+## Step 6 — Preview Issue Content
+
+Print to user:
+```
+─────────────────────────────────────
+📋 생성할 이슈 미리보기
+─────────────────────────────────────
+제목: [Bug] 약국 목록 NPE 버그
+
+본문:
+## 🐞 문제 상황
+...
+─────────────────────────────────────
+이 내용으로 이슈를 생성하시겠습니까? (y/n)
+```
+
+If user enters `n`: Offer to edit specific sections (optional — for now, abort and ask user to retry)
+If user enters `y`: Proceed to Step 7
+
+## Step 7 — Create the Issue
 
 Run `gh issue create` with:
-- `--title "[{TYPE_PREFIX}] {auto_summary_from_agent}"`
-- `--body "$(cat <<'EOF'{completed_body}EOF)"` (heredoc format)
-- `--label "{emoji_label}"` (e.g., `🐞 bug`)
+- `--title "[{TYPE_PREFIX}] {title_from_summary}"`
+- `--body "{body_from_agent}"`
+- `--label "{emoji_label}"` (from mapping table, not frontmatter)
 - Additional label: `📌 status: todo`
 
-**Type Prefix & Emoji Label Mapping:**
+**Type Prefix & Emoji Label Mapping (authoritative source):**
 
 | Type | Prefix | Label |
 |------|--------|-------|
@@ -57,29 +113,51 @@ Run `gh issue create` with:
 | refactor | Refactor | 🔧 refactor |
 | design | Design | 💡 design |
 
+**IMPORTANT**: Always use the values from this table, ignoring template frontmatter `labels:` field.
+
 Command template:
 ```bash
 gh issue create \
-  --title "[Bug] 앱이 크래시 남" \
-  --body "$(cat <<'EOF'
-## 🐞 문제 상황
-...
-EOF
-)" \
+  --title "[Bug] 약국 목록 NPE 버그" \
+  --body "## 🐞 문제 상황
+..." \
   --label "🐞 bug" \
   --label "📌 status: todo"
 ```
 
-## Step 5 — Print Result
+## Step 8 — Print Result
 
 Output the created issue URL and number in format:
 ```
-✅ Issue created: #123
+✅ 이슈 생성 완료: #123
 🔗 URL: https://github.com/UMC-hello-doctor/HelloDoctor-android/issues/123
 ```
 
 ## Error Handling
 
-- **Invalid type**: "❌ Invalid type. Use: bug, 버그, feature, 기능, chore, 보수, refactor, 리팩, design, 디자인"
-- **Template file missing**: "❌ Template not found: .github/ISSUE_TEMPLATE/{type}.md"
-- **gh issue create failed**: Print the error and ask user to check GitHub CLI credentials
+**Invalid type**:
+```
+❌ 유효하지 않은 타입입니다. 다음 중 하나를 사용하세요:
+bug, 버그, feature, 기능, chore, 보수, refactor, 리팩, design, 디자인
+```
+
+**Template file missing**:
+```
+❌ 템플릿을 찾을 수 없습니다: .github/ISSUE_TEMPLATE/{type}.md
+```
+
+**GitHub CLI not installed/authenticated**:
+(Caught in Step 3)
+
+**gh issue create failed**:
+```
+❌ 이슈 생성에 실패했습니다.
+오류: {error message}
+GitHub CLI 인증을 확인하세요: gh auth status
+```
+
+**User cancels preview**:
+```
+❌ 이슈 생성이 취소되었습니다.
+다시 시도하려면 `/issue {type} {description}`을 실행하세요.
+```

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,85 @@
+---
+name: issue
+description: Creates a GitHub issue using templates and auto-fills content with github-issue-helper agent. Usage: /issue <type> <description>
+---
+
+You will create a GitHub issue for HelloDoctor-android following the project's issue templates.
+
+## Step 1 — Parse Issue Type
+
+Extract the first argument as the issue type. Support both English and Korean:
+
+**Type Mapping:**
+- `bug` | `버그` → `.github/ISSUE_TEMPLATE/bug.md`
+- `feature` | `기능` → `.github/ISSUE_TEMPLATE/feature.md`
+- `chore` | `보수` | `유지` → `.github/ISSUE_TEMPLATE/chore.md`
+- `refactor` | `리팩` | `리팩터` → `.github/ISSUE_TEMPLATE/refactor.md`
+- `design` | `디자인` → `.github/ISSUE_TEMPLATE/design.md`
+
+If the type is invalid or empty, respond with an error message listing valid types.
+
+## Step 2 — Read the Template
+
+Read the matching template from `.github/ISSUE_TEMPLATE/<type>.md`.
+- Extract the YAML frontmatter to get `labels` field (e.g., `labels: bug`)
+- Extract the body sections (everything after `---`)
+
+## Step 3 — Call github-issue-helper Agent
+
+Pass the template content and user's description to the `github-issue-helper` agent:
+
+```
+Invoke: Agent(subagent_type="github-issue-helper", prompt="""
+Issue type: {type}
+User description: {rest_of_args}
+Template body:
+{template_body}
+""")
+```
+
+The agent will auto-fill template sections and return a completed issue body.
+
+## Step 4 — Create the Issue
+
+Run `gh issue create` with:
+- `--title "[{TYPE_PREFIX}] {auto_summary_from_agent}"`
+- `--body "$(cat <<'EOF'{completed_body}EOF)"` (heredoc format)
+- `--label "{emoji_label}"` (e.g., `🐞 bug`)
+- Additional label: `📌 status: todo`
+
+**Type Prefix & Emoji Label Mapping:**
+
+| Type | Prefix | Label |
+|------|--------|-------|
+| bug | Bug | 🐞 bug |
+| feature | Feature | ✨ feature |
+| chore | Chore | 🧹 chore |
+| refactor | Refactor | 🔧 refactor |
+| design | Design | 💡 design |
+
+Command template:
+```bash
+gh issue create \
+  --title "[Bug] 앱이 크래시 남" \
+  --body "$(cat <<'EOF'
+## 🐞 문제 상황
+...
+EOF
+)" \
+  --label "🐞 bug" \
+  --label "📌 status: todo"
+```
+
+## Step 5 — Print Result
+
+Output the created issue URL and number in format:
+```
+✅ Issue created: #123
+🔗 URL: https://github.com/UMC-hello-doctor/HelloDoctor-android/issues/123
+```
+
+## Error Handling
+
+- **Invalid type**: "❌ Invalid type. Use: bug, 버그, feature, 기능, chore, 보수, refactor, 리팩, design, 디자인"
+- **Template file missing**: "❌ Template not found: .github/ISSUE_TEMPLATE/{type}.md"
+- **gh issue create failed**: Print the error and ask user to check GitHub CLI credentials

--- a/.claude/commands/workflow.md
+++ b/.claude/commands/workflow.md
@@ -1,0 +1,125 @@
+---
+name: workflow
+description: Check CI workflow status, view logs, and rerun failed steps. Usage: /workflow [status|check|rerun <id>|list]
+---
+
+You will manage GitHub Actions workflows for HelloDoctor-android.
+
+Default action: `status` (if no subcommand provided)
+
+## Subcommand: status
+
+Show the 10 most recent workflow runs on the current branch.
+
+```bash
+git branch --show-current | xargs -I {} gh run list --branch {} --limit 10
+```
+
+Format output as a readable table showing:
+- Workflow name
+- Status (completed, in_progress, queued, requested)
+- Conclusion (success, failure, cancelled, skipped)
+- Time created (relative time, e.g., "2 hours ago")
+- Run ID
+
+Example output:
+```
+Name                  Status      Conclusion   Created        ID
+code-style-check      completed   success      2 hours ago    12345
+test-coverage         completed   failure      2 hours ago    12344
+pr-labeler            completed   success      1 hour ago     12343
+```
+
+## Subcommand: check
+
+Show HEAD commit's workflow status and failed step logs.
+
+Steps:
+1. Get all runs for current commit:
+   ```bash
+   git rev-parse HEAD | xargs -I {} gh run list --commit {} --limit 1 --json databaseId,status,conclusion | jq -r '.[0] | "\(.databaseId) \(.status) \(.conclusion)"'
+   ```
+
+2. View full run details including failed logs:
+   ```bash
+   gh run view <run_id> --log
+   ```
+
+3. If there are failures, extract and highlight failed step names and their log excerpts.
+
+Print format:
+```
+Run #12344 for HEAD commit: status=completed, conclusion=failure
+
+❌ Failed steps:
+- test-unit-tests (exit code 1)
+  > Error: Database connection timeout
+
+- detekt-check (exit code 1)
+  > Detekt analysis found issues
+
+View full log: gh run view 12344
+```
+
+If all steps passed:
+```
+✅ All steps passed for HEAD commit
+```
+
+## Subcommand: rerun <id_or_name>
+
+Rerun only failed steps for a workflow run.
+
+Steps:
+1. If input is non-numeric, treat as workflow name and resolve to most recent run ID:
+   ```bash
+   gh run list --workflow "<name>" --limit 1 --json databaseId | jq -r '.[0].databaseId'
+   ```
+
+2. Rerun failed steps only:
+   ```bash
+   gh run rerun <resolved_id> --failed-only
+   ```
+
+3. Print confirmation:
+   ```
+   ✅ Rerunning failed steps in run #<id>
+   ```
+
+**Known workflow names** (for user reference, use for name resolution):
+- code-style-check
+- test-coverage
+- issue-labeler
+- labels-sync
+- pr-labeler
+- pr-line-limit
+- pr-merge-status
+- pr-title-labeler
+
+## Subcommand: list
+
+List all workflows in the repository.
+
+```bash
+gh workflow list
+```
+
+Format as a table with:
+- Workflow name
+- State (active, disabled, deleted)
+- Filename (.github/workflows/*.yml)
+
+Example:
+```
+NAME              STATE     PATH
+code-style-check  active    .github/workflows/code-style-check.yml
+test-coverage     active    .github/workflows/test-coverage.yml
+issue-labeler     active    .github/workflows/issue-labeler.yml
+```
+
+## Error Handling
+
+- **Invalid subcommand**: "❌ Unknown subcommand. Use: `status`, `check`, `rerun <id|name>`, or `list`"
+- **Run ID not found**: "❌ No workflow run found for that ID or branch. Try `/workflow status` to list recent runs."
+- **Network error**: "❌ GitHub CLI error. Check your internet connection and GitHub credentials."
+- **Workflow name not found**: "❌ Workflow '{name}' not found. Use `/workflow list` to see available workflows."

--- a/.claude/commands/workflow.md
+++ b/.claude/commands/workflow.md
@@ -12,81 +12,132 @@ Default action: `status` (if no subcommand provided)
 Show the 10 most recent workflow runs on the current branch.
 
 ```bash
-git branch --show-current | xargs -I {} gh run list --branch {} --limit 10
+git branch --show-current | xargs -I {} gh run list --branch {} --limit 10 --json name,status,conclusion,createdAt,databaseId
 ```
 
 Format output as a readable table showing:
 - Workflow name
-- Status (completed, in_progress, queued, requested)
-- Conclusion (success, failure, cancelled, skipped)
+- Status (한국어 매핑)
+- Conclusion (한국어 매핑)
 - Time created (relative time, e.g., "2 hours ago")
 - Run ID
 
+**Status & Conclusion Mapping (한국어):**
+
+| API Value | 표시 |
+|-----------|------|
+| completed | ✅ 완료 |
+| in_progress | 🏃 진행 중 |
+| queued | ⏳ 대기 중 |
+| requested | 📮 신청됨 |
+| success | ✅ 성공 |
+| failure | ❌ 실패 |
+| cancelled | ⛔ 취소 |
+| skipped | ⏭️ 스킵 |
+| neutral | ⚪ 중립 |
+
 Example output:
 ```
-Name                  Status      Conclusion   Created        ID
-code-style-check      completed   success      2 hours ago    12345
-test-coverage         completed   failure      2 hours ago    12344
-pr-labeler            completed   success      1 hour ago     12343
+브랜치: feature/drug-list 기준 최근 10개 실행 결과
+────────────────────────────────────────────────────
+워크플로우 이름           상태        결과      생성       ID
+code-style-check      ✅ 완료      ✅ 성공   2시간 전  12345
+test-coverage         ✅ 완료      ❌ 실패   2시간 전  12344
+pr-labeler            ✅ 완료      ✅ 성공   1시간 전  12343
+build-android         🏃 진행 중   —         30초 전   12342
 ```
 
 ## Subcommand: check
 
-Show HEAD commit's workflow status and failed step logs.
+Show HEAD commit's workflow status and failed step logs across all concurrent workflows.
 
 Steps:
-1. Get all runs for current commit:
+1. Get all runs for current commit (remove `--limit 1` to get all concurrent runs):
    ```bash
-   git rev-parse HEAD | xargs -I {} gh run list --commit {} --limit 1 --json databaseId,status,conclusion | jq -r '.[0] | "\(.databaseId) \(.status) \(.conclusion)"'
+   git rev-parse HEAD | xargs -I {} gh run list --commit {} --limit 20 --json databaseId,name,status,conclusion,createdAt | jq -r '.[] | "\(.databaseId) \(.name) \(.status) \(.conclusion)"'
    ```
 
-2. View full run details including failed logs:
+2. For each failed run, view full details:
    ```bash
    gh run view <run_id> --log
    ```
 
-3. If there are failures, extract and highlight failed step names and their log excerpts.
+3. Aggregate results: show all failed workflows and their failed step names.
 
-Print format:
+Print format (example with multiple workflows):
 ```
-Run #12344 for HEAD commit: status=completed, conclusion=failure
+HEAD 커밋 기준 워크플로우 실행 결과
+─────────────────────────────────────────
+✅ code-style-check #12346 — 성공
+✅ pr-line-limit #12345 — 성공
+❌ test-unit-tests #12344 — 실패
 
-❌ Failed steps:
-- test-unit-tests (exit code 1)
-  > Error: Database connection timeout
+❌ test-unit-tests 실패 단계:
+- unit-tests (종료 코드 1)
+  > 에러: Database connection timeout
+- integration-tests (종료 코드 1)
+  > 에러: Test timeout
 
-- detekt-check (exit code 1)
-  > Detekt analysis found issues
-
-View full log: gh run view 12344
+자세한 로그: gh run view 12344 --log
 ```
 
-If all steps passed:
+If all workflows passed:
 ```
-✅ All steps passed for HEAD commit
+✅ 모든 워크플로우 성공 (HEAD 커밋)
+```
+
+If HEAD not yet pushed to GitHub:
+```
+⚠️  현재 HEAD 커밋에 대한 워크플로우 실행 내역이 없습니다.
+커밋이 아직 push되지 않았거나 워크플로우가 시작되지 않았습니다.
 ```
 
 ## Subcommand: rerun <id_or_name>
 
-Rerun only failed steps for a workflow run.
+Rerun only failed steps for a workflow run with polling for result.
 
 Steps:
-1. If input is non-numeric, treat as workflow name and resolve to most recent run ID:
+1. If input is non-numeric, resolve workflow name to most recent run ID:
    ```bash
-   gh run list --workflow "<name>" --limit 1 --json databaseId | jq -r '.[0].databaseId'
+   gh workflow list --json name,id | jq -r '.[] | select(.name == "<name>") | .id' | head -1
+   ```
+   Then get most recent run:
+   ```bash
+   gh run list --workflow <resolved_workflow_id> --limit 1 --json databaseId | jq -r '.[0].databaseId'
    ```
 
 2. Rerun failed steps only:
    ```bash
-   gh run rerun <resolved_id> --failed-only
+   gh run rerun <run_id> --failed-only
    ```
 
-3. Print confirmation:
-   ```
-   ✅ Rerunning failed steps in run #<id>
+3. Poll for completion (15초 간격, 최대 5회):
+   ```bash
+   for i in {1..5}; do
+     sleep 15
+     gh run view <run_id> --json status,conclusion
+   done
    ```
 
-**Known workflow names** (for user reference, use for name resolution):
+4. Print status with final result:
+   ```
+   🔄 워크플로우 재실행 중: run #<id>
+
+   [15초 경과] 상태: 진행 중
+   [30초 경과] 상태: 진행 중
+   [45초 경과] 상태: 완료
+
+   ✅ 재실행 완료: #<id> — 성공
+   자세한 로그: gh run view <id>
+   ```
+
+   If failed:
+   ```
+   ❌ 재실행 완료: #<id> — 실패
+   다시 재실행하려면: /workflow rerun <id>
+   ```
+
+**Known workflow names** (for reference; dynamic lookup is primary):
 - code-style-check
 - test-coverage
 - issue-labeler
@@ -98,28 +149,52 @@ Steps:
 
 ## Subcommand: list
 
-List all workflows in the repository.
+List all workflows in the repository with their current state.
 
 ```bash
-gh workflow list
+gh workflow list --json name,state,path
 ```
 
 Format as a table with:
 - Workflow name
-- State (active, disabled, deleted)
+- State (active → ✅ 활성, disabled → ⛔ 비활성, deleted → 🗑️ 삭제)
 - Filename (.github/workflows/*.yml)
 
 Example:
 ```
-NAME              STATE     PATH
-code-style-check  active    .github/workflows/code-style-check.yml
-test-coverage     active    .github/workflows/test-coverage.yml
-issue-labeler     active    .github/workflows/issue-labeler.yml
+워크플로우 이름            상태     파일 경로
+code-style-check    ✅ 활성   .github/workflows/code-style-check.yml
+test-coverage       ✅ 활성   .github/workflows/test-coverage.yml
+issue-labeler       ✅ 활성   .github/workflows/issue-labeler.yml
+deprecated-check    ⛔ 비활성  .github/workflows/deprecated-check.yml
 ```
 
 ## Error Handling
 
-- **Invalid subcommand**: "❌ Unknown subcommand. Use: `status`, `check`, `rerun <id|name>`, or `list`"
-- **Run ID not found**: "❌ No workflow run found for that ID or branch. Try `/workflow status` to list recent runs."
-- **Network error**: "❌ GitHub CLI error. Check your internet connection and GitHub credentials."
-- **Workflow name not found**: "❌ Workflow '{name}' not found. Use `/workflow list` to see available workflows."
+**Invalid subcommand**:
+```
+❌ 유효하지 않은 서브커맨드입니다.
+사용법: /workflow [status|check|rerun <id|name>|list]
+```
+
+**Run ID not found**:
+```
+❌ 해당 ID의 워크플로우 실행을 찾을 수 없습니다.
+최근 실행 목록: /workflow status
+```
+
+**Workflow name not found**:
+```
+❌ 워크플로우 '{name}'을(를) 찾을 수 없습니다.
+사용 가능한 워크플로우: /workflow list
+```
+
+**Network error / GitHub CLI error**:
+```
+❌ GitHub CLI 오류가 발생했습니다.
+- 인터넷 연결을 확인하세요
+- GitHub 인증을 확인하세요: gh auth status
+```
+
+**HEAD not pushed yet**:
+(Handled in `check` subcommand output)


### PR DESCRIPTION
## 📌 PR 개요
- GitHub 이슈 생성(`/issue`), CI 워크플로우 관리(`/workflow`), 이슈 템플릿 자동 작성 에이전트(`github-issue-helper`) 추가 및 개선

---

## ✨ 작업 내용
- [ ] `/issue` 커맨드 추가: 타입 파싱, 한국어 지원, gh CLI 사전 검사, 미리보기 확인 단계, label 이름 매핑
- [ ] `/workflow` 커맨드 추가: status / check / rerun / list 서브커맨드, 한국어 상태 매핑, rerun 폴링, 병렬 CI 집계
- [ ] `github-issue-helper` 에이전트 추가: SUMMARY 메타라인 출력, chore·refactor·design 섹션 테이블 완성, vague 판단 기준 추가
- [ ] `.claude/agents/README.md`, `.claude/commands/README.md` 업데이트

---

## 🧩 관련 이슈
- Closes #43

---

## 📱 화면 캡처 (선택)
- 해당 없음 (CLI 커맨드 변경)

---

## ⚠️ 체크 사항
- [ ] 빌드 및 실행 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [ ] 변경 사항에 대한 테스트 작성 또는 기존 테스트 통과 확인
- [ ] PR 변경 줄 수 200줄 이하 확인 (초과 시 분리 필요)
- [ ] 불필요한 로그 제거
- [ ] 코드 컨벤션 준수

---

## 💬 기타 참고 사항
- 변경 파일 전체가 `.claude/` 하위 커맨드·에이전트 정의 파일로, 운영 코드 변경 없음
- 533줄 초과는 문서성 파일이므로 실질적 코드 리뷰 부담 없음