### PR TITLE
[Chore] JaCoCo 빌드 에러 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,21 +1,21 @@
 import java.io.FileInputStream
 import java.util.Properties
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
+import org.gradle.testing.jacoco.tasks.JacocoReport
 
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    //def version in project gradle
     id("androidx.navigation.safeargs.kotlin")
     id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
     kotlin("plugin.parcelize")
 
-    // 🔧 CI/CD 플러그인 추가
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     id("io.gitlab.arturbosch.detekt") version "1.23.6"
     jacoco
 }
+
 val propertiesFile = rootProject.file("gradle.properties")
 val properties = Properties()
 if (propertiesFile.exists()) {
@@ -39,19 +39,17 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        //AI API KEY
+
         buildConfigField(
             "String",
             "AI_API_KEY",
             "\"${properties.getProperty("AI_API_KEY", "")}\""
         )
-        //프로젝트 서버
         buildConfigField(
             "String",
             "SERVER_BASE_URL",
             "\"${properties.getProperty("SERVER_BASE_URL", "https://api.hellodoctor.dev")}\""
         )
-        //navermap
         buildConfigField(
             "String",
             "NAVER_MAP_CLIENT_ID",
@@ -62,12 +60,12 @@ android {
             "NAVER_MAP_CLIENT_SECRET",
             "\"${properties.getProperty("NAVER_MAP_CLIENT_SECRET", "")}\""
         )
-        //OAUTH
         buildConfigField(
             "String",
             "GOOGLE_OAUTH_CLIENT_ID",
             "\"${properties.getProperty("GOOGLE_OAUTH_CLIENT_ID", "")}\""
         )
+
         manifestPlaceholders["NAVER_MAP_CLIENT_ID"] =
             project.properties["NAVER_MAP_CLIENT_ID"] ?: ""
     }
@@ -82,22 +80,34 @@ android {
     }
 
     buildTypes {
-        //디버그시(run app시)에도 release key
         getByName("debug") {
             signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
+            enableUnitTestCoverage = true
         }
+
         getByName("release") {
             signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
     kotlinOptions {
         jvmTarget = "17"
+    }
+
+    testOptions {
+        unitTests.all {
+            it.extensions.configure(org.gradle.testing.jacoco.plugins.JacocoTaskExtension::class.java) {
+                isIncludeNoLocationClasses = true
+                excludes = listOf("jdk.internal.*")
+            }
+        }
     }
 }
 
@@ -105,8 +115,83 @@ jacoco {
     toolVersion = "0.8.11"
 }
 
-// Jacoco code coverage verification: 80% 이상
-tasks.withType<JacocoCoverageVerification>().configureEach {
+val jacocoExcludedFiles = listOf(
+    "**/R.class",
+    "**/R$*.class",
+    "**/BuildConfig.*",
+    "**/Manifest*.*",
+    "**/*Test*.*",
+    "android/**/*.*",
+
+    // Android / Kotlin generated
+    "**/*\$ViewInjector*.*",
+    "**/*\$ViewBinder*.*",
+    "**/BR.*",
+    "**/DataBinderMapperImpl.*",
+    "**/*Binding*.*",
+    "**/*MapperImpl*.*",
+    "**/*Companion*.*",
+    "**/*Module*.*",
+    "**/*Dagger*.*",
+    "**/*Hilt*.*",
+    "**/*_Hilt*.*",
+    "**/*MembersInjector*.*",
+    "**/*_Factory*.*",
+    "**/*_Provide*Factory*.*",
+    "**/*Extensions*.*",
+    "**/*\$Result.*",
+    "**/*\$Result$*.*",
+    "**/*Directions*.*",
+    "**/*Args*.*",
+
+    // Compose / lambda / synthetic
+    "**/*ComposableSingletons*.*",
+    "**/*\$Lambda$*.*",
+    "**/*\$inlined$*.*"
+)
+
+val debugTree = fileTree("${layout.buildDirectory.get().asFile}/tmp/kotlin-classes/debug") {
+    exclude(jacocoExcludedFiles)
+}
+
+val mainJavaTree = fileTree("${layout.buildDirectory.get().asFile}/intermediates/javac/debug/classes") {
+    exclude(jacocoExcludedFiles)
+}
+
+val jacocoExecutionData = fileTree(layout.buildDirectory.get().asFile) {
+    include(
+        "jacoco/testDebugUnitTest.exec",
+        "outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec"
+    )
+}
+
+tasks.register<JacocoReport>("jacocoDebugReport") {
+    group = "verification"
+    description = "Generate JaCoCo coverage report for debug unit tests"
+
+    dependsOn("testDebugUnitTest")
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        csv.required.set(false)
+    }
+
+    classDirectories.setFrom(files(debugTree, mainJavaTree))
+    sourceDirectories.setFrom(files("src/main/java", "src/main/kotlin"))
+    executionData.setFrom(jacocoExecutionData)
+}
+
+tasks.register<JacocoCoverageVerification>("jacocoCoverageVerification") {
+    group = "verification"
+    description = "Verify JaCoCo coverage threshold for debug unit tests"
+
+    dependsOn("testDebugUnitTest")
+
+    classDirectories.setFrom(files(debugTree, mainJavaTree))
+    sourceDirectories.setFrom(files("src/main/java", "src/main/kotlin"))
+    executionData.setFrom(jacocoExecutionData)
+
     violationRules {
         rule {
             limit {
@@ -116,14 +201,17 @@ tasks.withType<JacocoCoverageVerification>().configureEach {
     }
 }
 
-// Jacoco test coverage verification 태스크 설정
-tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
-    classDirectories.setFrom(files(layout.buildDirectory.dir("tmp/kotlin-classes/debug")))
-    sourceDirectories.setFrom(files("src/main/kotlin"))
-    executionData.setFrom(files(layout.buildDirectory.file("jacoco/testDebugUnitTest.exec")))
+tasks.register("testCoverage") {
+    group = "verification"
+    description = "Run unit tests, generate coverage report, and verify coverage"
+
+    dependsOn(
+        "testDebugUnitTest",
+        "jacocoDebugReport",
+        "jacocoCoverageVerification"
+    )
 }
 
-// 🔧 ktlint 설정
 ktlint {
     android.set(false)
     ignoreFailures.set(false)
@@ -133,7 +221,6 @@ ktlint {
     }
 }
 
-// 🔧 detekt 설정 (deprecation 수정)
 detekt {
     toolVersion = "1.23.6"
     config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
@@ -141,7 +228,6 @@ detekt {
 }
 
 dependencies {
-    //basic lib
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
@@ -150,46 +236,38 @@ dependencies {
     implementation(libs.androidx.fragment)
     implementation(libs.androidx.cardview)
     implementation(libs.play.services.location)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 
-    // --- Navigation ---
     implementation("androidx.navigation:navigation-fragment-ktx:2.8.4")
     implementation("androidx.navigation:navigation-ui-ktx:2.8.4")
 
-    // --- UI / 레이아웃 ---
     implementation("androidx.fragment:fragment-ktx:1.8.5")
     implementation("androidx.viewpager2:viewpager2:1.1.0")
     implementation("androidx.gridlayout:gridlayout:1.0.0")
     implementation("androidx.recyclerview:recyclerview:1.3.2")
 
-    // --- 아키텍처 / 코루틴 ---
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 
-    // --- 네트워크 (Retrofit) ---
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
 
-    // --- 이미지 로딩 (Glide + KSP) ---
     implementation("com.github.bumptech.glide:glide:4.16.0")
     ksp("com.github.bumptech.glide:ksp:4.16.0")
 
-    // --- 인증 (Credential Manager / Google 로그인) ---
     implementation("androidx.credentials:credentials:1.3.0")
     implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("com.google.android.gms:play-services-auth:21.4.0")
 
-    // --- 지도 (Naver Maps) ---
     implementation("com.naver.maps:map-sdk:3.23.0")
 
-    // --- Hilt (DI) ---
     implementation("com.google.dagger:hilt-android:2.57.2")
     ksp("com.google.dagger:hilt-compiler:2.57.2")
 
-    // --- Room DB ---
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")
     ksp("androidx.room:room-compiler:2.6.1")

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,7 +17,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:defaultNavHost="true"
-        app:navGraph="@navigation/nav_auth" />
+        app:navGraph="@navigation/nav_main" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 📌 PR 개요
- `jacocoTestCoverageVerification` 태스크 미생성으로 인한 빌드 실패를 수정합니다.

---

## ✨ 작업 내용
이번 PR에서 수행한 작업을 정리해주세요.
- [ ] `tasks.named` → `tasks.register`로 교체하여 태스크 미존재 에러 해결
- [ ] `jacocoDebugReport` (커버리지 리포트) 태스크 분리 등록
- [ ] `jacocoCoverageVerification` (커버리지 검증) 태스크 분리 등록
- [ ] `testCoverage` 통합 태스크 추가 (테스트 실행 → 리포트 → 검증 순서)
- [ ] `enableUnitTestCoverage = true` 설정 추가 (debug 빌드)
- [ ] `activity_main.xml` navGraph `nav_auth` → `nav_main` 수정

---

## 🧩 관련 이슈
- Closes #46

---

## 📱 화면 캡처 (선택)
- UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

---

## ⚠️ 체크 사항
PR을 올리기 전에 아래 항목을 확인해주세요.
- [ ] 빌드 및 실행 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [ ] 변경 사항에 대한 테스트 작성 또는 기존 테스트 통과 확인
- [ ] PR 변경 줄 수 200줄 이하 확인 (초과 시 분리 필요)
- [ ] 불필요한 로그 제거
- [ ] 코드 컨벤션 준수

---

## 💬 기타 참고 사항
- `tasks.named`는 해당 태스크가 이미 등록된 경우에만 동작하며, JaCoCo 플러그인이 Android 프로젝트에서 `jacocoTestCoverageVerification` 태스크를 자동 생성하지 않아 빌드가 실패했습니다.
- 기존 두 블록(`tasks.withType` + `tasks.named`)을 `tasks.register`로 통합하고 실행 데이터 경로를 명시적으로 지정했습니다.